### PR TITLE
Fix TypeError while running tests with scikit-learn 0.24.0

### DIFF
--- a/test_autofeat.py
+++ b/test_autofeat.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
             successful_tests.add(check.func.__name__)
             check(estimator)
     # additionally check the class, but don't run all the other tests
-    for estimator, check in check_estimator(AutoFeatRegressor, generate_only=True):
+    for estimator, check in check_estimator(AutoFeatRegressor(), generate_only=True):
         if check.func.__name__ not in successful_tests:
             print(check.func.__name__)
             successful_tests.add(check.func.__name__)
@@ -176,7 +176,7 @@ if __name__ == '__main__':
             successful_tests.add(check.func.__name__)
             check(estimator)
     # additionally check the class, but don't run all the other tests
-    for estimator, check in check_estimator(AutoFeatClassifier, generate_only=True):
+    for estimator, check in check_estimator(AutoFeatClassifier(), generate_only=True):
         if check.func.__name__ not in successful_tests:
             print(check.func.__name__)
             successful_tests.add(check.func.__name__)

--- a/test_featsel.py
+++ b/test_featsel.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
             successful_tests.add(check.func.__name__)
             check(estimator)
     # additionally check the class, but don't run all the other tests
-    for estimator, check in check_estimator(FeatureSelector, generate_only=True):
+    for estimator, check in check_estimator(FeatureSelector(), generate_only=True):
         if check.func.__name__ not in successful_tests:
             print(check.func.__name__)
             successful_tests.add(check.func.__name__)


### PR DESCRIPTION
Running `test_featsel.py` and `test_autofeat.py` with `scikit-learn` `0.24.0` throws the following error.
```
TypeError: Passing a class was deprecated in version 0.23 and isn't supported anymore from 0.24.Please pass an instance instead
```
Passing instances instead of clases fixed it.