### PR TITLE
Use numba for standardization

### DIFF
--- a/autofeat/autofeat.py
+++ b/autofeat/autofeat.py
@@ -451,6 +451,10 @@ class AutoFeatModel(BaseEstimator):
             self.always_return_numpy = temp
         return self.prediction_model_.score(df[self.good_cols_].to_numpy(), target)
 
+    @property
+    def n_features_in_(self):
+        return len(self.feateng_cols_)
+
 
 class AutoFeatRegressor(AutoFeatModel, BaseEstimator, RegressorMixin):
     """Short-cut initialization for AutoFeatModel with problem_type: regression"""

--- a/autofeat/autofeatlight.py
+++ b/autofeat/autofeatlight.py
@@ -251,5 +251,6 @@ class AutoFeatLight(BaseEstimator):
             df = pd.DataFrame(X_new, columns=df.columns, index=df.index)
         if self.verbose > 0:
             print("[AutoFeatLight] New data shape: %i x %i" % df.shape)
+        self.n_features_in_ = len(self.original_columns_)
         # return either dataframe or array
         return df if self.return_df_ else df.to_numpy()

--- a/autofeat/nb_utils.py
+++ b/autofeat/nb_utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Author: Jeethu Rao <jboloor@acm.org>
+# License: MIT
+
+import numba as nb
+import numpy as np
+
+
+@nb.njit(inline='always')
+def nb_apply_along_axis(func1d, axis, arr):
+    assert arr.ndim == 2
+    assert axis in [0, 1]
+    if axis == 0:
+        result = np.empty(arr.shape[1])
+        for i in range(len(result)):
+            result[i] = func1d(arr[:, i])
+    else:
+        result = np.empty(arr.shape[0])
+        for i in range(len(result)):
+            result[i] = func1d(arr[i, :])
+    return result
+
+
+@nb.njit(cache=True)
+def nb_nanmean(array, axis):
+    return nb_apply_along_axis(np.nanmean, axis, array)
+
+
+@nb.njit(cache=True)
+def nb_nanstd(array, axis):
+    return nb_apply_along_axis(np.nanstd, axis, array)
+
+
+@nb.njit(cache=True)
+def nb_standard_scale(array):
+    return (array - nb_nanmean(array, 0)) / nb_nanstd(array, 0)


### PR DESCRIPTION
On the heels of #25, here's the second part of the change, to use numba for standardization in the feature selection module. The numba accelerated standard scaler implementation in `nb_utils.py` is a very barebones, without all the bells and whistles that come with sklearn's [StandardScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html). Also, I found a couple of warning from the sklearn estimator test suite about [SLEP010](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html) while running the tests. Added `n_features_in_` property/attribute to all the estimators to address those warnings.