### PR TITLE
Use numba jit for feature generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can either download the code from here and include the autofeat folder in yo
 
     $ pip install autofeat
 
-The library requires Python 3! Other dependencies: `numpy`, `pandas`, `scikit-learn`, `sympy`, `joblib`, and `pint`
+The library requires Python 3! Other dependencies: `numpy`, `pandas`, `scikit-learn`, `sympy`, `joblib`, `pint` and `numba`.
 
 
 ### Paper

--- a/autofeat/__init__.py
+++ b/autofeat/__init__.py
@@ -3,7 +3,7 @@
 # License: MIT
 
 name = "autofeat"
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 from .autofeatlight import AutoFeatLight  # noqa
 from .autofeat import AutoFeatModel, AutoFeatRegressor, AutoFeatClassifier  # noqa
 from .featsel import FeatureSelector  # noqa


### PR DESCRIPTION
This is hopefully the last in my series of numba related changes. This change jit compiles the feature generation functions to get rid of the overhead of calling `lambdify`'d functions (at the cost of a one time jit compilation overhead, on first invocation). The numba jit bails out in some cases (for instance: with `abs` function calls on arithmetic expressions). In such cases, the code falls back on the non jit compiled version of the function.

This change might also help with #23, although not significantly so, since the usecase there is to transform one row at a time.